### PR TITLE
Use open binary instead of Terminals own binary

### DIFF
--- a/XcodeWay/Navigator/FTGTerminalNavigator.m
+++ b/XcodeWay/Navigator/FTGTerminalNavigator.m
@@ -16,8 +16,8 @@
     NSString *projectPath = [[FTGEnvironmentManager sharedManager] projectPath];
     NSString *projectFolderPath = [projectPath stringByDeletingLastPathComponent];
 
-    [NSTask ftg_runTaskWithLaunchPath:@"/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal"
-                            arguments:@[ projectFolderPath ]];
+    [NSTask ftg_runTaskWithLaunchPath:@"/usr/bin/open"
+                            arguments:@[@"-a", @"Terminal", projectFolderPath]];
 }
 
 @end


### PR DESCRIPTION
This avoids opening multiple instances of Terminal, also it makes
Terminal the front most window.
