### PR TITLE
Refactor opening iTerm

### DIFF
--- a/XcodeWay.xcodeproj/project.pbxproj
+++ b/XcodeWay.xcodeproj/project.pbxproj
@@ -183,7 +183,9 @@
 				998E7ADA19A89FAB006E9A2F /* Frameworks */,
 				998E7AD919A89FAB006E9A2F /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		998E7AD919A89FAB006E9A2F /* Products */ = {
 			isa = PBXGroup;

--- a/XcodeWay/Navigator/FTGiTermNavigator.m
+++ b/XcodeWay/Navigator/FTGiTermNavigator.m
@@ -12,15 +12,9 @@
 
 - (void)navigate
 {
-    NSString *projectPath = [[FTGEnvironmentManager sharedManager] projectPath];
-    NSString *projectFolderPath = [projectPath stringByDeletingLastPathComponent];
-
-    NSString *iTermPath = @"/Applications/iTerm.app/Contents/MacOS/iTerm";
-    if ([[NSFileManager defaultManager] fileExistsAtPath:iTermPath]) {
-        [NSTask ftg_runTaskWithLaunchPath:iTermPath
-                                arguments:@[ projectFolderPath ]];
-    } else {
-        [NSAlert ftg_showMessage:@"iTerm.app is expected to be in Applications folder"];
+    BOOL launchediTerm = [[NSWorkspace sharedWorkspace] launchApplication:@"iTerm"];
+    if (launchediTerm == NO) {
+        [NSAlert ftg_showMessage:@"Could not launch iTerm"];
     }
 }
 

--- a/XcodeWay/Navigator/FTGiTermNavigator.m
+++ b/XcodeWay/Navigator/FTGiTermNavigator.m
@@ -12,8 +12,7 @@
 
 - (void)navigate
 {
-    BOOL launchediTerm = [[NSWorkspace sharedWorkspace] launchApplication:@"iTerm"];
-    if (launchediTerm == NO) {
+    if ([[NSWorkspace sharedWorkspace] launchApplication:@"iTerm"] == NO) {
         [NSAlert ftg_showMessage:@"Could not launch iTerm"];
     }
 }


### PR DESCRIPTION
This PR refactors opening iTerm from Xcode. I had problems opening iTerm2 because it couldn’t find the binary that is was pointing to. Also, when I changed it to point to the new one, it always opened a new instance of iTerm which is not typically what you want.

This is now fixed by refactoring `FTGiTermNavigator.m`

``` objc
    if ([[NSWorkspace sharedWorkspace] launchApplication:@"iTerm"] == NO) {
        [NSAlert ftg_showMessage:@"Could not launch iTerm"];
    }
```

So instead of opening the binary file for the app, it uses the shared workspace which would either open iTerm if it isn’t open or bring it to front if it is.

Hope you like it
