### PR TITLE
Remove hard-coded local path

### DIFF
--- a/XcodeWay.xcodeproj/project.pbxproj
+++ b/XcodeWay.xcodeproj/project.pbxproj
@@ -327,7 +327,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cp \"${SRCROOT}/XcodeWayExtensions/Script/XcodeWayScript.scpt\" \"/Users/khoa/Library/Application Scripts/com.fantageek.XcodeWayApp.XcodeWayExtensions\"";
+			shellScript = "cp \"${SRCROOT}/XcodeWayExtensions/Script/XcodeWayScript.scpt\" \"${HOME}/Library/Application Scripts/com.fantageek.XcodeWayApp.XcodeWayExtensions\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
The current version on master references `/Users/khoa` in the extension's Copy Applescript phase. Changing this to `${HOME}` will let it run on other machines.